### PR TITLE
Define a timeout for the SSH connection

### DIFF
--- a/teamcity-gerrit-trigger-server/src/main/java/org/saulis/GerritClient.java
+++ b/teamcity-gerrit-trigger-server/src/main/java/org/saulis/GerritClient.java
@@ -18,6 +18,7 @@ public class GerritClient {
 
     private static final Logger LOG = Logger.getLogger(Loggers.VCS_CATEGORY + GerritClient.class);
     private static final int DEFAULT_GERRIT_PORT = 29418;
+    private static final int SSH_TIMEOUT = 10; // in seconds
     private JSch jsch;
 
     public GerritClient() {
@@ -71,7 +72,7 @@ public class GerritClient {
 
         Session session = jsch.getSession(context.getUsername(), server, port);
         session.setConfig("StrictHostKeyChecking", "no");
-        session.connect();
+        session.connect(SSH_TIMEOUT);
 
         return session;
     }


### PR DESCRIPTION
Tries to avoid the possibility for an infinite wait when the connection has been lost.

Based on Saulis/teamcity-gerrit-trigger#1 but that repository appears to be dead.